### PR TITLE
make the example actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ func main() {
 	term.Set(
 		p.Or(
 			p.Action(p.Seq(p.Named("i", term), p.S("*"), p.Named("j", num)), func(v p.Values) interface{} {
-				i := v.Get("ii").(int)
-				j := v.Get("jj").(int)
+				i := v.Get("i").(int)
+				j := v.Get("j").(int)
 				return i * j
 			}),
 			p.Action(p.Seq(p.Named("i", term), p.S("/"), p.Named("j", num)), func(v p.Values) interface{} {

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ func main() {
 				return i * j
 			}),
 			p.Action(p.Seq(p.Named("i", term), p.S("/"), p.Named("j", num)), func(v p.Values) interface{} {
-				i := v.Get("a").(int)
-				j := v.Get("b").(int)
+				i := v.Get("i").(int)
+				j := v.Get("j").(int)
 				return i / j
 			}),
 			num,


### PR DESCRIPTION
little typo fixed fields `ii` and `jj` do not exist
Dividing still not really works, as it's returning `int`, but at least it won't panic